### PR TITLE
Add CI for CRY.ME app compilation and bundling.

### DIFF
--- a/.github/workflows/bundle_cryme_app.yml
+++ b/.github/workflows/bundle_cryme_app.yml
@@ -1,0 +1,19 @@
+name: Bundle CRY.ME app
+on: push
+jobs:
+  bundle_from_docker:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository
+      - name: checkout repository
+        uses: actions/checkout@v3
+      - name: CRY.ME bundling
+        shell: bash
+        run: |
+          # Launch docker compilation
+          cd cryme_app && make app_bundle_src_docker;
+      - name: CRY.ME archive compiled app
+        uses: actions/upload-artifact@v3
+        with:
+          name: cry.me.src.bundle.tar.gz
+          path: cry.me.src.bundle.tar.gz

--- a/.github/workflows/compile_cryme_app.yml
+++ b/.github/workflows/compile_cryme_app.yml
@@ -1,0 +1,19 @@
+name: Compile CRY.ME app
+on: push
+jobs:
+  compile_from_docker:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository
+      - name: checkout repository
+        uses: actions/checkout@v3
+      - name: CRY.ME compilation
+        shell: bash
+        run: |
+          # Launch docker compilation and tar the result
+          cd cryme_app && make app_build_docker && tar acvf cry.me.build.tar.gz build/;
+      - name: CRY.ME archive compiled app
+        uses: actions/upload-artifact@v3
+        with:
+          name: cry.me.build.tar.gz
+          path: cryme_app/cry.me.build.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![compilation](https://github.com/ANSSI-FR/cry-me/actions/workflows/compile_cryme_app.yml/badge.svg?branch=master)](https://github.com/ANSSI-FR/cry-me/actions/workflows/compile_cryme_app.yml)
+[![bundling](https://github.com/ANSSI-FR/cry-me/actions/workflows/bundle_cryme_app.yml/badge.svg?branch=master)](https://github.com/ANSSI-FR/cry-me/actions/workflows/bundle_cryme_app.yml)
+
 # CRY.ME - A Flawed Messaging Application for Educational Purposes
 
 ## The CRY.ME project
@@ -89,6 +92,10 @@ cryme_app$ make app_bundle_src_docker
 ...
 ```
 
+You can also download the bundle from the CI artifacts on
+the [github actions page](https://github.com/ANSSI-FR/cry-me/actions) as bundling the application
+also runs in the CI.
+
 ## The CRY.ME Android compilation
 
 ### Pre-built packages
@@ -115,6 +122,10 @@ Please be aware, however, that the release packages are **not signed**, and henc
 not directly installable on target devices (which is not the case of debug packages). Signing `apk`
 release packages is out of the scope of the project, please refer to the appropriate Android
 resources to achieve this.
+
+You can also download the build bundle from the CI artifacts on
+the [github actions page](https://github.com/ANSSI-FR/cry-me/actions) as compilation of the
+application also runs in the CI.
 
 ### Compilation from scratch
 


### PR DESCRIPTION
Add CI for app compilation and bundling (these should produce downloadable artifacts).